### PR TITLE
Get tests passing under 3.6

### DIFF
--- a/src/contexts/plugins/importing/assertion_rewriting.py
+++ b/src/contexts/plugins/importing/assertion_rewriting.py
@@ -147,7 +147,12 @@ class AssertionChildVisitor(ast.NodeVisitor):
                     ], keywords=[]),
                     ast.Call(func=self.load('tuple'), args=[
                         ast.GeneratorExp(self.clsname(self.load('@x')), [
-                            ast.comprehension(ast.Name('@x', ast.Store()), self.load('@contexts_assertion_var2'), []),
+                            ast.comprehension(
+                                target=ast.Name('@x', ast.Store()),
+                                iter=self.load('@contexts_assertion_var2'),
+                                ifs=[],
+                                is_async=False,
+                            ),
                         ]),
                     ], keywords=[]),
                     self.clsname(self.load('@contexts_assertion_var2'))


### PR DESCRIPTION
Hi, not sure if this is the kind of contribution you're looking for, but i checked out the repo today and immediately got stuck running the tests:

```
    File "/home/harry/workspace/Contexts/src/contexts/plugins/importing/assertion_rewriting.py", line 32, in get_code
      return self.source_to_code(source, path)
    File "/home/harry/workspace/Contexts/src/contexts/plugins/importing/assertion_rewriting.py", line 38, in source_to_code
      transformer.visit(parsed)
    File "/usr/lib/python3.6/ast.py", line 253, in visit
      return visitor(node)
    File "/usr/lib/python3.6/ast.py", line 308, in generic_visit
      value = self.visit(value)
    File "/usr/lib/python3.6/ast.py", line 253, in visit
      return visitor(node)
    File "/usr/lib/python3.6/ast.py", line 308, in generic_visit
      value = self.visit(value)
    File "/usr/lib/python3.6/ast.py", line 253, in visit
      return visitor(node)
    File "/home/harry/workspace/Contexts/src/contexts/plugins/importing/assertion_rewriting.py", line 51, in visit_Assert
      statements = AssertionChildVisitor().visit(assert_node.test)
    File "/home/harry/workspace/Contexts/src/contexts/plugins/importing/assertion_rewriting.py", line 61, in visit
      ret = super().visit(node)
    File "/usr/lib/python3.6/ast.py", line 253, in visit
      return visitor(node)
    File "/home/harry/workspace/Contexts/src/contexts/plugins/importing/assertion_rewriting.py", line 150, in visit_Call
      ast.comprehension(ast.Name('@x', ast.Store()), self.load('@contexts_assertion_var2'), []),
  TypeError: comprehension constructor takes either 0 or 4 positional arguments
  
  During handling of the above exception, another exception occurred:
  
  Traceback (most recent call last):
    File "/home/harry/workspace/Contexts/src/contexts/core.py", line 283, in run_context
      yield
    File "/home/harry/workspace/Contexts/src/contexts/core.py", line 198, in run
      self.run_teardown()
    File "/home/harry/workspace/Contexts/src/contexts/core.py", line 213, in run_teardown
      run_with_test_data(teardown, self.example)
    File "/home/harry/workspace/Contexts/src/contexts/core.py", line 240, in run_with_test_data
      func()
    File "/home/harry/workspace/Contexts/test/plugin_tests/importing_tests/assertion_rewriting_tests.py", line 28, in cleanup_the_filesystem_and_sys_dot_modules
      del sys.modules[self.module_name]
  KeyError: 'assertion_rewriting_test_data'
```

looked to me like maybe an issue with `ast.comprehension` having changed for Python 3.6 maybe?  so i hacked in some random plausible values into the constructor and got passing tests again.  

probably needs sanity-checking!