### PR TITLE
use CDATA for failure messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ nosetests.xml
 .pydevproject
 *.sublime-project
 *.sublime-workspace
+.venv

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ sphinx
 flake8
 coverage
 coveralls
+lxml~=4.2

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ builtin_plugins = [
 
 setup(
     name="Contexts",
-    version="0.11.2",
+    version="0.12",
     author="Benjamin Hodgson",
     author_email="benjamin.hodgson@huddle.net",
     url="https://github.com/benjamin-hodgson/Contexts",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     package_dir={'': 'src'},
     packages=find_packages('src'),
     install_requires=["setuptools >= 1.0"],
-    extras_require={'colour': ["colorama >= 0.2.7"]},
+    extras_require={'colour': ["colorama >= 0.2.7"], 'lxml': ["lxml~=4.2"]},
     entry_points={
         'console_scripts': ['run-contexts=contexts.__main__:cmd'],
         'contexts.plugins': builtin_plugins,

--- a/src/contexts/plugins/reporting/xml.py
+++ b/src/contexts/plugins/reporting/xml.py
@@ -1,5 +1,6 @@
-from datetime import datetime, timedelta
 import io
+import re
+from datetime import datetime, timedelta
 from lxml import etree
 
 from . import context_name, format_exception, make_readable
@@ -76,6 +77,9 @@ class AssertionResult(Result):
             return 1
         return 0
 
+
+
+ANSI_ESCAPE = re.compile(r'\x1B\[[0-?]*[ -/]*[@-~]')
 
 class XmlReporter:
 
@@ -158,9 +162,9 @@ class XmlReporter:
             testcase_el,
             tag,
             type=tag,
-            message=test.msg
+            message=ANSI_ESCAPE.sub('', test.msg)
         )
-        failure_el.text = etree.CDATA(test.nfo)
+        failure_el.text = etree.CDATA(ANSI_ESCAPE.sub('', test.nfo))
 
 
     def test_run_ended(self):

--- a/src/contexts/plugins/reporting/xml.py
+++ b/src/contexts/plugins/reporting/xml.py
@@ -160,7 +160,7 @@ class XmlReporter:
             type=tag,
             message=test.msg
         )
-        failure_el.text = test.nfo
+        failure_el.text = etree.CDATA(test.nfo)
 
 
     def test_run_ended(self):

--- a/src/contexts/plugins/reporting/xml.py
+++ b/src/contexts/plugins/reporting/xml.py
@@ -6,6 +6,8 @@ from lxml import etree
 from . import context_name, format_exception, make_readable
 from ...plugin_interface import NO_EXAMPLE
 
+ANSI_ESCAPE = re.compile(r'\x1B\[[0-?]*[ -/]*[@-~]')
+
 
 class Result:
 
@@ -38,7 +40,6 @@ class Result:
     @property
     def passed(self):
         return not(self.failure or self.errors)
-
 
     def __len__(self):
         return len(self.children)
@@ -77,9 +78,6 @@ class AssertionResult(Result):
             return 1
         return 0
 
-
-
-ANSI_ESCAPE = re.compile(r'\x1B\[[0-?]*[ -/]*[@-~]')
 
 class XmlReporter:
 
@@ -165,7 +163,6 @@ class XmlReporter:
             message=ANSI_ESCAPE.sub('', test.msg)
         )
         failure_el.text = etree.CDATA(ANSI_ESCAPE.sub('', test.nfo))
-
 
     def test_run_ended(self):
         self.suites.stop()

--- a/src/contexts/plugins/reporting/xml.py
+++ b/src/contexts/plugins/reporting/xml.py
@@ -62,7 +62,7 @@ class AssertionResult(Result):
 
     @property
     def nfo(self):
-        return '\n'.join(format_exception(self.failure or self.error))
+        return '\n' + '\n'.join(format_exception(self.failure or self.error)) + '\n'
 
     @property
     def failures(self):

--- a/test/plugin_tests/reporting_tests/xml_tests.py
+++ b/test/plugin_tests/reporting_tests/xml_tests.py
@@ -203,7 +203,7 @@ class When_an_assertion_fails(XmlOutputContext):
 
     def it_should_have_the_traceback_as_CDATA(self):
         tb = self.formatted_tb.replace('|n', '\n')
-        expected = f'\n{tb}\n'
+        expected = '\n' + tb + \n'
         assert(self.test.find("failure").text == expected)
         assert(b'CDATA' in etree.tostring(self.test.find('failure')))
 
@@ -328,7 +328,7 @@ class When_an_assertion_errors(XmlOutputContext):
 
     def it_should_have_the_traceback_as_CDATA(self):
         tb = self.formatted_tb.replace('|n', '\n')
-        expected = f'\n{tb}\n'
+        expected = '\n' + tb + \n'
         assert(self.test.find("error").text == expected)
         assert(b'CDATA' in etree.tostring(self.test.find('error')))
 

--- a/test/plugin_tests/reporting_tests/xml_tests.py
+++ b/test/plugin_tests/reporting_tests/xml_tests.py
@@ -203,7 +203,7 @@ class When_an_assertion_fails(XmlOutputContext):
 
     def it_should_have_the_traceback_as_CDATA(self):
         tb = self.formatted_tb.replace('|n', '\n')
-        expected = '\n' + tb + \n'
+        expected = '\n' + tb + '\n'
         assert(self.test.find("failure").text == expected)
         assert(b'CDATA' in etree.tostring(self.test.find('failure')))
 
@@ -328,7 +328,7 @@ class When_an_assertion_errors(XmlOutputContext):
 
     def it_should_have_the_traceback_as_CDATA(self):
         tb = self.formatted_tb.replace('|n', '\n')
-        expected = '\n' + tb + \n'
+        expected = '\n' + tb + '\n'
         assert(self.test.find("error").text == expected)
         assert(b'CDATA' in etree.tostring(self.test.find('error')))
 

--- a/test/plugin_tests/reporting_tests/xml_tests.py
+++ b/test/plugin_tests/reporting_tests/xml_tests.py
@@ -1,7 +1,7 @@
 import collections
 import os
 import tempfile
-import xml.etree.ElementTree as ET
+from lxml import etree
 
 from contexts.plugins.reporting import xml
 from .. import tools
@@ -69,8 +69,8 @@ class XmlOutputContext:
 
     @property
     def test_suites(self):
-        tree = ET.parse(self.filename).getroot()
-        print(ET.tostring(tree))
+        tree = etree.parse(self.filename).getroot()
+        print(etree.tostring(tree))
         return tree
 
 

--- a/test/plugin_tests/reporting_tests/xml_tests.py
+++ b/test/plugin_tests/reporting_tests/xml_tests.py
@@ -261,7 +261,6 @@ class When_an_assertion_fails_with_an_ansi_escape_code_for_colour(XmlOutputConte
         self.xml.assertion_failed(assertion, self.exception)
         self.xml.test_run_ended()
 
-
     def the_message_should_be_stripped_of_control_chars(self):
         assert(self.test.find("failure").get("message") == "Gotcha")
 
@@ -358,4 +357,3 @@ class When_an_assertion_errors(XmlOutputContext):
     @property
     def test(self):
         return self.suite.find('testcase')
-

--- a/test/plugin_tests/reporting_tests/xml_tests.py
+++ b/test/plugin_tests/reporting_tests/xml_tests.py
@@ -199,6 +199,11 @@ class When_an_assertion_fails(XmlOutputContext):
     def it_should_have_a_short_message(self):
         assert(self.test.find("failure").get("message") == "Gotcha")
 
+    def it_should_have_the_traceback_as_CDATA(self):
+        tb = self.formatted_tb.replace('|n', '\n')
+        expected = f'\n{tb}\n'
+        assert(self.test.find("failure").text == expected)
+
     def it_should_not_have_been_skipped(self):
         assert(self.test.find("skipped") is None)
 
@@ -278,6 +283,11 @@ class When_an_assertion_errors(XmlOutputContext):
 
     def it_should_have_a_short_message(self):
         assert(self.test.find("error").get("message") == "Gotcha")
+
+    def it_should_have_the_traceback_as_CDATA(self):
+        tb = self.formatted_tb.replace('|n', '\n')
+        expected = f'\n{tb}\n'
+        assert(self.test.find("error").text == expected)
 
     def it_should_not_have_been_skipped(self):
         assert(self.test.find("skipped") is None)

--- a/test/plugin_tests/reporting_tests/xml_tests.py
+++ b/test/plugin_tests/reporting_tests/xml_tests.py
@@ -69,7 +69,8 @@ class XmlOutputContext:
 
     @property
     def test_suites(self):
-        tree = etree.parse(self.filename).getroot()
+        parser = etree.XMLParser(strip_cdata=False)
+        tree = etree.parse(self.filename, parser=parser).getroot()
         print(etree.tostring(tree))
         return tree
 
@@ -203,6 +204,7 @@ class When_an_assertion_fails(XmlOutputContext):
         tb = self.formatted_tb.replace('|n', '\n')
         expected = f'\n{tb}\n'
         assert(self.test.find("failure").text == expected)
+        assert(b'CDATA' in etree.tostring(self.test.find('failure')))
 
     def it_should_not_have_been_skipped(self):
         assert(self.test.find("skipped") is None)
@@ -288,6 +290,7 @@ class When_an_assertion_errors(XmlOutputContext):
         tb = self.formatted_tb.replace('|n', '\n')
         expected = f'\n{tb}\n'
         assert(self.test.find("error").text == expected)
+        assert(b'CDATA' in etree.tostring(self.test.find('error')))
 
     def it_should_not_have_been_skipped(self):
         assert(self.test.find("skipped") is None)


### PR DESCRIPTION
cf #20, this wraps error and failure text output in CDATA to avoid any xml parsing issues if the test traceback or error message has weird characters in.

(still not entirely sure the bug wasn't jenkins' fault, but worth a try)

- switch from builitin python xml to `lxml`
- adds unit tests

still needs

* [x] strip ANSI escape colour codes from `message` section at least
