### PR TITLE
docs: fix simple typo, sepcified -> specified

### DIFF
--- a/src/contexts/__init__.py
+++ b/src/contexts/__init__.py
@@ -15,7 +15,7 @@ __all__ = [
 
 def main():
     """
-    Call contexts.run() with the sepcified arguments,
+    Call contexts.run() with the specified arguments,
     exiting with code 0 if the test run was successful,
     code 1 if unsuccessful.
     """


### PR DESCRIPTION
There is a small typo in src/contexts/__init__.py.

Should read `specified` rather than `sepcified`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md